### PR TITLE
Add test project

### DIFF
--- a/Otp.NET.sln
+++ b/Otp.NET.sln
@@ -6,6 +6,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{D0E9D08A-7F6
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Otp.NET", "src\Otp.NET\Otp.NET.csproj", "{EF104BCD-4F86-494E-81E1-D69A5C851430}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Otp.NET.Test", "src\Otp.NET.Test\Otp.NET.Test.csproj", "{1843EE6C-16A4-4A2F-B961-8FC8B0157414}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -28,6 +30,18 @@ Global
 		{EF104BCD-4F86-494E-81E1-D69A5C851430}.Release|x64.Build.0 = Release|Any CPU
 		{EF104BCD-4F86-494E-81E1-D69A5C851430}.Release|x86.ActiveCfg = Release|Any CPU
 		{EF104BCD-4F86-494E-81E1-D69A5C851430}.Release|x86.Build.0 = Release|Any CPU
+		{1843EE6C-16A4-4A2F-B961-8FC8B0157414}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1843EE6C-16A4-4A2F-B961-8FC8B0157414}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1843EE6C-16A4-4A2F-B961-8FC8B0157414}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1843EE6C-16A4-4A2F-B961-8FC8B0157414}.Debug|x64.Build.0 = Debug|Any CPU
+		{1843EE6C-16A4-4A2F-B961-8FC8B0157414}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1843EE6C-16A4-4A2F-B961-8FC8B0157414}.Debug|x86.Build.0 = Debug|Any CPU
+		{1843EE6C-16A4-4A2F-B961-8FC8B0157414}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1843EE6C-16A4-4A2F-B961-8FC8B0157414}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1843EE6C-16A4-4A2F-B961-8FC8B0157414}.Release|x64.ActiveCfg = Release|Any CPU
+		{1843EE6C-16A4-4A2F-B961-8FC8B0157414}.Release|x64.Build.0 = Release|Any CPU
+		{1843EE6C-16A4-4A2F-B961-8FC8B0157414}.Release|x86.ActiveCfg = Release|Any CPU
+		{1843EE6C-16A4-4A2F-B961-8FC8B0157414}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Otp.NET.Test/HotpTest.cs
+++ b/src/Otp.NET.Test/HotpTest.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Linq;
+using NUnit.Framework;
+using OtpNet;
+
+namespace Otp.NET.Test
+{
+    [TestFixture]
+    public class HotpTest
+    {
+        private static readonly byte[] rfc4226Secret = new byte[] {
+            0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38,
+            0x39, 0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36,
+            0x37, 0x38, 0x39, 0x30
+            };
+
+        [TestCase(OtpHashMode.Sha1, 0, "755224")]
+        [TestCase(OtpHashMode.Sha1, 1, "287082")]
+        [TestCase(OtpHashMode.Sha1, 2, "359152")]
+        [TestCase(OtpHashMode.Sha1, 3, "969429")]
+        [TestCase(OtpHashMode.Sha1, 4, "338314")]
+        [TestCase(OtpHashMode.Sha1, 5, "254676")]
+        [TestCase(OtpHashMode.Sha1, 6, "287922")]
+        [TestCase(OtpHashMode.Sha1, 7, "162583")]
+        [TestCase(OtpHashMode.Sha1, 8, "399871")]
+        [TestCase(OtpHashMode.Sha1, 9, "520489")]
+        public void ComputeHOTPRfc4226Test(OtpHashMode hash, long counter, string expectedOtp)
+        {
+            Hotp otpCalc = new Hotp(rfc4226Secret, hash, expectedOtp.Length);
+            string otp = otpCalc.ComputeHOTP(counter);
+            Assert.That(otp, Is.EqualTo(expectedOtp));
+        }
+    }
+}

--- a/src/Otp.NET.Test/Otp.NET.Test.csproj
+++ b/src/Otp.NET.Test/Otp.NET.Test.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="nunit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Otp.NET\Otp.NET.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Otp.NET.Test/TotpTest.cs
+++ b/src/Otp.NET.Test/TotpTest.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Text;
+using NUnit.Framework;
+using OtpNet;
+
+namespace Otp.NET.Test
+{
+    [TestFixture()]
+    public class TotpTest
+    {
+        private const string rfc6238SecretSha1 = "12345678901234567890";
+        private const string rfc6238SecretSha256 = "12345678901234567890123456789012";
+        private const string rfc6238SecretSha512 = "1234567890123456789012345678901234567890123456789012345678901234";
+
+        [TestCase(rfc6238SecretSha1, OtpHashMode.Sha1, 59, "94287082")]
+        [TestCase(rfc6238SecretSha256, OtpHashMode.Sha256, 59, "46119246")]
+        [TestCase(rfc6238SecretSha512, OtpHashMode.Sha512, 59, "90693936")]
+        [TestCase(rfc6238SecretSha1, OtpHashMode.Sha1, 1111111109, "07081804")]
+        [TestCase(rfc6238SecretSha256, OtpHashMode.Sha256, 1111111109, "68084774")]
+        [TestCase(rfc6238SecretSha512, OtpHashMode.Sha512, 1111111109, "25091201")]
+        [TestCase(rfc6238SecretSha1, OtpHashMode.Sha1, 1111111111, "14050471")]
+        [TestCase(rfc6238SecretSha256, OtpHashMode.Sha256, 1111111111, "67062674")]
+        [TestCase(rfc6238SecretSha512, OtpHashMode.Sha512, 1111111111, "99943326")]
+        [TestCase(rfc6238SecretSha1, OtpHashMode.Sha1, 1234567890, "89005924")]
+        [TestCase(rfc6238SecretSha256, OtpHashMode.Sha256, 1234567890, "91819424")]
+        [TestCase(rfc6238SecretSha512, OtpHashMode.Sha512, 1234567890, "93441116")]
+        [TestCase(rfc6238SecretSha1, OtpHashMode.Sha1, 2000000000, "69279037")]
+        [TestCase(rfc6238SecretSha256, OtpHashMode.Sha256, 2000000000, "90698825")]
+        [TestCase(rfc6238SecretSha512, OtpHashMode.Sha512, 2000000000, "38618901")]
+        [TestCase(rfc6238SecretSha1, OtpHashMode.Sha1, 20000000000, "65353130")]
+        [TestCase(rfc6238SecretSha256, OtpHashMode.Sha256, 20000000000, "77737706")]
+        [TestCase(rfc6238SecretSha512, OtpHashMode.Sha512, 20000000000, "47863826")]
+        public void ComputeTOTPTest(string secret, OtpHashMode hash, long timestamp, string expectedOtp)
+        {
+            Totp otpCalc = new Totp(Encoding.UTF8.GetBytes(secret), 30, hash, expectedOtp.Length);
+            DateTime time = DateTimeOffset.FromUnixTimeSeconds(timestamp).DateTime;
+            string otp = otpCalc.ComputeTotp(time);
+            Assert.That(otp, Is.EqualTo(expectedOtp));
+        }
+    }
+}


### PR DESCRIPTION
This patch adds a NUnit test project which is checking the test vectors from RFC 4226 and RFC 6238.

It should fix issue #18 