### PR TITLE
Enable usage with a generic IKeyProvider

### DIFF
--- a/src/Otp.NET/Hotp.cs
+++ b/src/Otp.NET/Hotp.cs
@@ -52,6 +52,20 @@ namespace OtpNet
             this.hotpSize = hotpSize;
         }
 
+        /// <summary>
+        /// Create a HOTP instance
+        /// </summary>
+        /// <param name="key">The key to use in HOTP calculations</param>
+        /// <param name="mode">The hash mode to use</param>
+        /// <param name="hotpSize">The number of digits that the returning HOTP should have.  The default is 6.</param>
+        public Hotp(IKeyProvider key, OtpHashMode mode = OtpHashMode.Sha1, int hotpSize = 6)
+            : base(key, mode)
+        {
+            VerifyParameters(hotpSize);
+
+            this.hotpSize = hotpSize;
+        }
+
         private static void VerifyParameters(int hotpSize)
         {
             if(!(hotpSize >= 6))

--- a/src/Otp.NET/Otp.cs
+++ b/src/Otp.NET/Otp.cs
@@ -47,7 +47,7 @@ namespace OtpNet
         protected readonly OtpHashMode hashMode;
 
         /// <summary>
-        /// Constructor for the abstract class.  This is to guarantee that all implementations have a secret key
+        /// Constructor for the abstract class using an explicit secret key
         /// </summary>
         /// <param name="secretKey"></param>
         /// <param name="mode">The hash mode to use</param>
@@ -60,6 +60,21 @@ namespace OtpNet
 
             // when passing a key into the constructor the caller may depend on the reference to the key remaining intact.
             this.secretKey = new InMemoryKey(secretKey);
+
+            this.hashMode = mode;
+        }
+
+        /// <summary>
+        /// Constructor for the abstract class using a generic key provider
+        /// </summary>
+        /// <param name="key"></param>
+        /// <param name="mode">The hash mode to use</param>
+        public Otp(IKeyProvider key, OtpHashMode mode)
+        {
+            if (key == null)
+                throw new ArgumentNullException("key");
+
+            this.secretKey = key;
 
             this.hashMode = mode;
         }

--- a/src/Otp.NET/Totp.cs
+++ b/src/Otp.NET/Totp.cs
@@ -70,6 +70,26 @@ namespace OtpNet
             this.correctedTime = timeCorrection ?? TimeCorrection.UncorrectedInstance;
         }
 
+        /// <summary>
+        /// Create a TOTP instance
+        /// </summary>
+        /// <param name="key">The secret key to use in TOTP calculations</param>
+        /// <param name="step">The time window step amount to use in calculating time windows.  The default is 30 as recommended in the RFC</param>
+        /// <param name="mode">The hash mode to use</param>
+        /// <param name="totpSize">The number of digits that the returning TOTP should have.  The default is 6.</param>
+        /// <param name="timeCorrection">If required, a time correction can be specified to compensate of an out of sync local clock</param>
+        public Totp(IKeyProvider key, int step = 30, OtpHashMode mode = OtpHashMode.Sha1, int totpSize = 6, TimeCorrection timeCorrection = null)
+            : base(key, mode)
+        {
+            VerifyParameters(step, totpSize);
+
+            this.step = step;
+            this.totpSize = totpSize;
+
+            // we never null check the corrected time object.  Since it's readonly, we'll ensure that it isn't null here and provide neatral functionality in this case.
+            this.correctedTime = timeCorrection ?? TimeCorrection.UncorrectedInstance;
+        }
+
         private static void VerifyParameters(int step, int totpSize)
         {
             if(!(step > 0))

--- a/test/Otp.NET.Test/HotpTest.cs
+++ b/test/Otp.NET.Test/HotpTest.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using Moq;
+using NUnit.Framework;
 
 namespace OtpNet.Test
 {
@@ -26,6 +27,18 @@ namespace OtpNet.Test
             Hotp otpCalc = new Hotp(rfc4226Secret, hash, expectedOtp.Length);
             string otp = otpCalc.ComputeHOTP(counter);
             Assert.That(otp, Is.EqualTo(expectedOtp));
+        }
+
+        [Test()]
+        public void ContructorWithKeyProviderTest()
+        {
+            //Mock a key provider which always returns an all-zero HMAC (causing an all-zero OTP)
+            Mock<IKeyProvider> keyMock = new Mock<IKeyProvider>();
+            keyMock.Setup(key => key.ComputeHmac(It.Is<OtpHashMode>(m => m == OtpHashMode.Sha1), It.IsAny<byte[]>())).Returns(new byte[20]);
+
+            var otp = new Hotp(keyMock.Object, OtpHashMode.Sha1, 6);
+            Assert.That(otp.ComputeHOTP(0), Is.EqualTo("000000"));
+            Assert.That(otp.ComputeHOTP(1), Is.EqualTo("000000"));
         }
     }
 }

--- a/test/Otp.NET.Test/Otp.NET.Test.csproj
+++ b/test/Otp.NET.Test/Otp.NET.Test.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Moq" Version="4.13.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Otp.NET.Test/TotpTest.cs
+++ b/test/Otp.NET.Test/TotpTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Text;
+using Moq;
 using NUnit.Framework;
 
 namespace OtpNet.Test
@@ -35,6 +36,17 @@ namespace OtpNet.Test
             DateTime time = DateTimeOffset.FromUnixTimeSeconds(timestamp).DateTime;
             string otp = otpCalc.ComputeTotp(time);
             Assert.That(otp, Is.EqualTo(expectedOtp));
+        }
+
+        [Test()]
+        public void ContructorWithKeyProviderTest()
+        {
+            //Mock a key provider which always returns an all-zero HMAC (causing an all-zero OTP)
+            Mock<IKeyProvider> keyMock = new Mock<IKeyProvider>();
+            keyMock.Setup(key => key.ComputeHmac(It.Is<OtpHashMode>(m => m == OtpHashMode.Sha1), It.IsAny<byte[]>())).Returns(new byte[20]);
+
+            var otp = new Totp(keyMock.Object, 30, OtpHashMode.Sha1, 6);
+            Assert.That(otp.ComputeTotp(), Is.EqualTo("000000"));
         }
     }
 }


### PR DESCRIPTION
Currently there is an interface (*IKeyProvider*) for non-standard keys available, but it cannot really be used since all the ?Otp classes are missing a constructor to initialize them with a different provider.

This patch adds those constructors plus the corresponding unit tests.