### PR TITLE
Add support for .NET 7

### DIFF
--- a/src/Otp.NET/Otp.NET.csproj
+++ b/src/Otp.NET/Otp.NET.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Version>1.3.0</Version>
-    <TargetFrameworks>net45;net6.0;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net48;net6.0;net7.0;netstandard1.3;netstandard2.0</TargetFrameworks>
     <PackageId>Otp.NET</PackageId>
     <Title>Otp.NET</Title>
     <Authors>Kyle Spearrin</Authors>
@@ -31,8 +31,8 @@ For documentation and examples visit the project website on GitHub at https://gi
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\..\LICENSE.txt" Pack="true" PackagePath="\"/>
-    <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
+    <None Include="..\..\LICENSE.txt" Pack="true" PackagePath="\" />
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
     <None Include="..\..\icon.png" Pack="true" PackagePath="\" />
   </ItemGroup>
 

--- a/test/Otp.NET.Test/Otp.NET.Test.csproj
+++ b/test/Otp.NET.Test/Otp.NET.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net7.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <RootNamespace>OtpNet.Test</RootNamespace>
   </PropertyGroup>


### PR DESCRIPTION
Add support for .NET 7.0
Change support for .NET 4.5 to .NET 4.8 since 4.5 is [no longer supported by Microsoft](https://dotnet.microsoft.com/en-us/download/visual-studio-sdks?cid=msbuild-developerpacks).