### PR TITLE
OTP properties

### DIFF
--- a/src/Otp.NET/Hotp.cs
+++ b/src/Otp.NET/Hotp.cs
@@ -39,6 +39,11 @@ public class Hotp : Otp
     private readonly int _hotpSize;
 
     /// <summary>
+    /// Gets the number of diigts that the returning HOTP should have.
+    /// </summary>
+    public int HotpSize => _hotpSize;
+
+    /// <summary>
     /// Create a HOTP instance
     /// </summary>
     /// <param name="secretKey">The secret key to use in HOTP calculations</param>

--- a/src/Otp.NET/Otp.cs
+++ b/src/Otp.NET/Otp.cs
@@ -46,6 +46,11 @@ public abstract class Otp
     protected readonly OtpHashMode _hashMode;
 
     /// <summary>
+    /// Gets the hash mode to use
+    /// </summary>
+    public OtpHashMode HashMode => _hashMode;
+
+    /// <summary>
     /// Constructor for the abstract class using an explicit secret key
     /// </summary>
     /// <param name="secretKey"></param>

--- a/src/Otp.NET/Totp.cs
+++ b/src/Otp.NET/Totp.cs
@@ -51,6 +51,21 @@ public class Totp : Otp
     private readonly TimeCorrection _correctedTime;
 
     /// <summary>
+    /// Gets the time window step amount to use in calculating time windows
+    /// </summary>
+    public int Step => _step;
+    
+    /// <summary>
+    /// Gets the number of digits that the returning TOTP should have
+    /// </summary>
+    public int TotpSize => _totpSize;
+    
+    /// <summary>
+    /// Gets the time correction to componensate out of sync local clock
+    /// </summary>
+    public TimeCorrection TimeCorrection => _correctedTime;
+
+    /// <summary>
     /// Create a TOTP instance
     /// </summary>
     /// <param name="secretKey">The secret key to use in TOTP calculations</param>


### PR DESCRIPTION
Fixes #45

Makes parameters passed into constructor readable from an instance (except secret key).