### PR TITLE
Expose TOTP window start

### DIFF
--- a/src/Otp.NET/Totp.cs
+++ b/src/Otp.NET/Totp.cs
@@ -249,6 +249,25 @@ public class Totp : Otp
         _step - (int)(((timestamp.Ticks - UnicEpocTicks) / TicksToSeconds) % _step);
 
     /// <summary>
+    /// Start of the current window based on UtcNow
+    /// </summary>
+    /// <remarks>
+    /// It will be corrected against a corrected UTC time using the provided time correction.
+    /// If none was provided then simply the current UTC will be used.
+    /// </remarks>
+    /// <returns>Start of the current window</returns>
+    public DateTime WindowStart()
+    {
+        return WindowStartForSpecificTime(_correctedTime.CorrectedUtcNow);
+    }
+
+    public DateTime WindowStart(DateTime timestamp) =>
+        WindowStartForSpecificTime(_correctedTime.GetCorrectedTime(timestamp));
+
+    private DateTime WindowStartForSpecificTime(DateTime timestamp) =>
+        timestamp.AddTicks(-(timestamp.Ticks - UnicEpocTicks) % (TicksToSeconds * _step));
+
+    /// <summary>
     /// Takes a time step and computes a TOTP code
     /// </summary>
     /// <param name="counter">time step</param>


### PR DESCRIPTION
Implements #46

Currently there is no way to retrieve elapsed, remaining or absolute time of a window for TOTP. The `RemainingSeconds()` method returns an integer and is therefore not satisfactory to trigger actions on new time window (such as updating UI).

While `Step` is now available, the calculation of required values is non-trivial and requires knowledge of implementation details (such as the used epoch).

This PR adds `WindowStart()` method that returns absolute time of the current TOTP window. That way, users can get:
* `DateTime` of when current window started ... `WindowStart()`
* elapsed `TimeSpan` as `WindowStart() - now`
* remaining `TimeSpan` as `now + TimeSpan.FromSeconds(Step) - WindowStart()`