### PR TITLE
.NET 9 and .NET 10 support

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 10.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.0.x
+        dotnet-version: 10.0.x
     - name: Restore signing key
       env:
         SIGNING_KEY: ${{ secrets.VS_SIGNING_KEY }}

--- a/src/Otp.NET/Otp.NET.csproj
+++ b/src/Otp.NET/Otp.NET.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
     <Version>1.4.0</Version>
-    <TargetFrameworks>net461;net5.0;net6.0;net7.0;net8.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net461;net5.0;net6.0;net7.0;net8.0;net9.0;net10.0;netstandard2.0</TargetFrameworks>
     <PackageId>Otp.NET</PackageId>
     <Title>Otp.NET</Title>
     <Authors>Kyle Spearrin</Authors>

--- a/test/Otp.NET.Test/Otp.NET.Test.csproj
+++ b/test/Otp.NET.Test/Otp.NET.Test.csproj
@@ -1,16 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <RootNamespace>OtpNet.Test</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="4.0.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="nunit" Version="4.4.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR adds .NET 9 and .NET 10 support to the library. I've also updated the libraries used for the tests and updated CI to use .NET 10 instead of .NET 8.

All the tests seem to pass correctly on my machine, let me know if anything should be changed.